### PR TITLE
Migrate unittest to Pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ deploy:
 	docker push rhasspy/rhasspy-hermes:$(version)
 
 test:
-	coverage run --source=$(SOURCE) -m unittest
+	coverage run --source=$(SOURCE) -m pytest
 	coverage report -m
 	coverage xml
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,4 +5,6 @@ flake8==3.7.9
 mypy==0.761
 -e git://github.com/pyinstaller/pyinstaller.git@9dd34bdfbaeaa4e0459bd3051d1caf0c7d75073f#egg=pyinstaller
 pylint==2.4.4
+pytest==5.3.2
+pytest-cov==2.8.1
 yamllint==1.20.0

--- a/tests/test_hermes_topics.py
+++ b/tests/test_hermes_topics.py
@@ -1,65 +1,52 @@
 """Tests for rhasspyhermes"""
-import unittest
-
 from rhasspyhermes.audioserver import AudioFrame, AudioPlayBytes, AudioPlayFinished
 from rhasspyhermes.nlu import NluIntent
 from rhasspyhermes.wake import HotwordDetected
 
 
-class HermesTestCase(unittest.TestCase):
-    """Tests for rhasspyhermes"""
+def test_topics():
+    """Check get_ methods for topics"""
+    siteId = "testSiteId"
+    requestId = "testRequestId"
+    intentName = "testIntent"
+    wakewordId = "testWakeWord"
 
-    def test_topics(self):
-        """Check get_ methods for topics"""
-        siteId = "testSiteId"
-        requestId = "testRequestId"
-        intentName = "testIntent"
-        wakewordId = "testWakeWord"
+    # AudioFrame
+    assert AudioFrame.is_topic(AudioFrame.topic(siteId=siteId))
+    assert AudioFrame.get_siteId(AudioFrame.topic(siteId=siteId)) == siteId
 
-        # AudioFrame
-        self.assertTrue(AudioFrame.is_topic(AudioFrame.topic(siteId=siteId)))
-        self.assertEqual(AudioFrame.get_siteId(AudioFrame.topic(siteId=siteId)), siteId)
+    # AudioPlayBytes
+    assert AudioPlayBytes.is_topic(
+        AudioPlayBytes.topic(siteId=siteId, requestId=requestId)
+    )
+    assert (
+        AudioPlayBytes.get_siteId(
+            AudioPlayBytes.topic(siteId=siteId, requestId=requestId)
+        )
+        == siteId
+    )
+    assert (
+        AudioPlayBytes.get_requestId(
+            AudioPlayBytes.topic(siteId=siteId, requestId=requestId)
+        )
+        == requestId
+    )
 
-        # AudioPlayBytes
-        self.assertTrue(
-            AudioPlayBytes.is_topic(
-                AudioPlayBytes.topic(siteId=siteId, requestId=requestId)
-            )
-        )
-        self.assertEqual(
-            AudioPlayBytes.get_siteId(
-                AudioPlayBytes.topic(siteId=siteId, requestId=requestId)
-            ),
-            siteId,
-        )
-        self.assertEqual(
-            AudioPlayBytes.get_requestId(
-                AudioPlayBytes.topic(siteId=siteId, requestId=requestId)
-            ),
-            requestId,
-        )
+    # AudioPlayFinished
+    assert AudioPlayFinished.is_topic(AudioPlayFinished.topic(siteId=siteId))
+    assert (
+        AudioPlayFinished.get_siteId(AudioPlayFinished.topic(siteId=siteId)) == siteId
+    )
 
-        # AudioPlayFinished
-        self.assertTrue(
-            AudioPlayFinished.is_topic(AudioPlayFinished.topic(siteId=siteId))
-        )
-        self.assertEqual(
-            AudioPlayFinished.get_siteId(AudioPlayFinished.topic(siteId=siteId)), siteId
-        )
+    # NluIntent
+    assert NluIntent.is_topic(NluIntent.topic(intentName=intentName))
+    assert (
+        NluIntent.get_intentName(NluIntent.topic(intentName=intentName)) == intentName
+    )
 
-        # NluIntent
-        self.assertTrue(NluIntent.is_topic(NluIntent.topic(intentName=intentName)))
-        self.assertEqual(
-            NluIntent.get_intentName(NluIntent.topic(intentName=intentName)), intentName
-        )
-
-        # HotwordDetected
-        self.assertTrue(
-            HotwordDetected.is_topic(HotwordDetected.topic(wakewordId=wakewordId))
-        )
-        self.assertEqual(
-            HotwordDetected.get_wakewordId(
-                HotwordDetected.topic(wakewordId=wakewordId)
-            ),
-            wakewordId,
-        )
+    # HotwordDetected
+    assert HotwordDetected.is_topic(HotwordDetected.topic(wakewordId=wakewordId))
+    assert (
+        HotwordDetected.get_wakewordId(HotwordDetected.topic(wakewordId=wakewordId))
+        == wakewordId
+    )


### PR DESCRIPTION
As discussed in https://github.com/rhasspy/rhasspy-hermes/issues/2 I did a rewrite of the unittest tests to pytest. For these simple tests it's quite trivial, but already here you see you can drop boilerplate code such as the TestCase class you don't need anymore.

I'm going to add some tests to improve code coverage, as this is a fundamental package for all Hermes-related packages in Rhasspy. More complex tests are possible with pytest without having to add too much boilerplate code.